### PR TITLE
Fix reserved identifier violations

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -10,25 +10,25 @@
 
 #define HT_SIZE_MIN 128
 
-#define HT_KEY_EQUALS(__k1,__kl1, __k2, __kl2) \
-            (((char *)(__k1))[0] == ((char *)(__k2))[0] && \
-            (__kl1) == (__kl2) && \
-            memcmp((__k1), (__k2), (__kl1)) == 0)
+#define HT_KEY_EQUALS(_k1, _kl1, _k2, _kl2) \
+            (((char *)(_k1))[0] == ((char *)(_k2))[0] && \
+            (_kl1) == (_kl2) && \
+            memcmp((_k1), (_k2), (_kl1)) == 0)
 
 
 #pragma pack(push, 1)
-typedef struct __ht_item {
+typedef struct _ht_item {
     uint32_t hash;
     char     kbuf[32];
     void    *key;
     size_t   klen;
     void    *data;
     size_t   dlen;
-    TAILQ_ENTRY(__ht_item) next;
+    TAILQ_ENTRY(_ht_item) next;
 } ht_item_t;
 
-typedef struct __ht_item_list {
-    TAILQ_HEAD(, __ht_item) head;
+typedef struct _ht_item_list {
+    TAILQ_HEAD(, _ht_item) head;
 #ifdef THREAD_SAFE
 #ifdef __MACH__
     OSSpinLock lock;
@@ -37,11 +37,11 @@ typedef struct __ht_item_list {
 #endif
 #endif
     size_t index;
-    TAILQ_ENTRY(__ht_item_list) iterator_next;
+    TAILQ_ENTRY(_ht_item_list) iterator_next;
 } ht_items_list_t;
 
 typedef struct {
-    TAILQ_HEAD(, __ht_item_list) head;
+    TAILQ_HEAD(, _ht_item_list) head;
 } ht_iterator_list_t;
 
 // NOTE : order here matters (and also numbering)
@@ -68,14 +68,14 @@ struct _hashtable_s {
 };
 #pragma pack(pop)
 
-typedef struct __ht_iterator_callback {
+typedef struct _ht_iterator_callback {
     int (*cb)();
     void *user;
     size_t count;
     hashtable_t *table;
 } ht_iterator_callback_t;
 
-typedef struct __ht_collector_arg {
+typedef struct _ht_collector_arg {
     linked_list_t *output;
     size_t count;
 } ht_collector_arg_t;

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -6,11 +6,11 @@
 #include <sys/ioctl.h>
 #include "rbtree.h"
 
-#define IS_BLACK(__n) (!(__n) || (__n)->color == RBTREE_COLOR_BLACK)
-#define IS_RED(__n) ((__n) && (__n)->color == RBTREE_COLOR_RED)
+#define IS_BLACK(_n) (!(_n) || (_n)->color == RBTREE_COLOR_BLACK)
+#define IS_RED(_n) ((_n) && (_n)->color == RBTREE_COLOR_RED)
 
-#define PAINT_BLACK(__n) { if (__n) (__n)->color = RBTREE_COLOR_BLACK; }
-#define PAINT_RED(__n) { if (__n) (__n)->color = RBTREE_COLOR_RED; }
+#define PAINT_BLACK(_n) { if (_n) (_n)->color = RBTREE_COLOR_BLACK; }
+#define PAINT_RED(_n) { if (_n) (_n)->color = RBTREE_COLOR_RED; }
 
 typedef enum {
     RBTREE_COLOR_RED = 0,

--- a/src/rqueue.c
+++ b/src/rqueue.c
@@ -8,10 +8,10 @@
 #define RQUEUE_FLAG_UPDATE (0x02)
 #define RQUEUE_FLAG_ALL    (0x03)
 
-#define RQUEUE_FLAG_ON(__addr, __flag) (rqueue_page_t *)(((intptr_t)__addr & -4) | __flag)
-#define RQUEUE_FLAG_OFF(__addr, __flag) (rqueue_page_t *)((intptr_t)__addr & ~__flag)
+#define RQUEUE_FLAG_ON(_addr, _flag) (rqueue_page_t *)(((intptr_t) (_addr) & -4) | (_flag))
+#define RQUEUE_FLAG_OFF(_addr, _flag) (rqueue_page_t *)((intptr_t) (_addr) & ~(_flag))
 
-#define RQUEUE_CHECK_FLAG(__addr, __flag) (((intptr_t)__addr & __flag) == __flag)
+#define RQUEUE_CHECK_FLAG(_addr, _flag) (((intptr_t) (_addr) & (_flag)) == (_flag))
 
 #define RQUEUE_MAX_RETRIES 1000
 


### PR DESCRIPTION
Some identifiers [do not fit](https://www.securecoding.cert.org/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier "Do not use identifiers that are reserved for the compiler implementation.") to the expected naming convention for the programming language "C". They can be renamed.

A few macro parameters can also be enclosed by additional parentheses.