### PR TITLE
bugfix: Fix node deletion segment fault issue & add unit test for deletion operation & add the missing hashtable error message

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -9,6 +9,7 @@ static char *graph_error_messages[] = {
     "No node has been found",
     "Label not present",
     "Allocation failed (OOM?)",
+    "Hashtable error",
     "The connection hasn't been found"
 };
 
@@ -91,7 +92,7 @@ graph_node_delete(graph_t *graph, char *label __attribute__ ((unused)), graph_no
         if (graph) graph->errno = EGRAPHNOLABEL;
         return -1;
     }
-    
+
     graph_node_t *node = NULL;
     int rc = ht_delete(graph->nodes, label, strlen(label), (void **)&node, NULL);
     if (rc != 0) {

--- a/src/graph.c
+++ b/src/graph.c
@@ -87,8 +87,13 @@ graph_destroy(graph_t *graph)
 int
 graph_node_delete(graph_t *graph, char *label __attribute__ ((unused)), graph_node_t **connections, int max_connections)
 {
+    if (!graph || !label) {
+        if (graph) graph->errno = EGRAPHNOLABEL;
+        return -1;
+    }
+    
     graph_node_t *node = NULL;
-    int rc = ht_delete(graph->nodes, node->label, strlen(node->label), (void **)&node, NULL);
+    int rc = ht_delete(graph->nodes, label, strlen(label), (void **)&node, NULL);
     if (rc != 0) {
         graph->errno = EGRAPHTABLEERR;
         return -1;

--- a/test/graph_test.c
+++ b/test/graph_test.c
@@ -95,6 +95,11 @@ int main(int argc, char **argv)
     test_node2 = graph_node_next(node2);
     ut_result(test_node == node3 && test_node2 == node4, "Node selection doesn't honor weights returned by the chooser");
 
+    ut_testing("Deleting an existing node from the graph");
+    int delete_ret;
+    delete_ret = graph_node_delete(graph, "start_node", NULL, 100);
+    ut_result(delete_ret == 0, "Delete failed");
+
     graph_destroy(graph);
 
     ut_summary();


### PR DESCRIPTION
The original code [`int rc = ht_delete(graph->nodes, node->label, strlen(node->label), (void **)&node, NULL);` ](https://github.com/xant/libhl/blob/master/src/graph.c#L91) dereferences the NULL pointer, this results in a segment fault. 